### PR TITLE
[FIX] Corrige importação de multiplos eventos por lote

### DIFF
--- a/pycnab240/file.py
+++ b/pycnab240/file.py
@@ -131,9 +131,9 @@ class Lot(object):
         self._events.append(new_event)
         return new_event
 
-    def get_active_event(self, create=False):
+    def get_active_event(self, seg_name, create=False):
         for event in self._events:
-            if event._is_open:
+            if event._is_open and seg_name not in [x.__class__.__name__ for x in event.segments]:
                 return event
         if create:
             return self.create_new_event()
@@ -210,7 +210,7 @@ class File(object):
         elif seg_name == 'TrailerLote':
             lot.add_trailer(vals)
         else:
-            event = lot.get_active_event(create=True)
+            event = lot.get_active_event(seg_name, create=True)
             event.add_segment(seg_name, vals)
 
     def close_file(self):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pycnab240',
-    version='0.1.14',
+    version='0.1.15',
     author='Trustcode',
     author_email='suporte@trustcode.com.br',
     url='https://github.com/Trust-Code/PyTrustCnab240',

--- a/tests/test_file.py
+++ b/tests/test_file.py
@@ -25,7 +25,7 @@ class TestPyCnab240(unittest.TestCase):
         self.assertEqual(self.comparison_file[1],
                          str(self.file.get_active_lot().header))
         self.assertEqual(self.comparison_file[2],
-                         str(self.file.get_active_lot().get_active_event().
+                         str(self.file.get_active_lot().get_active_event(None).
                          segments[0]))
 
     def test_close_file(self):


### PR DESCRIPTION
Caso um segmento já exista no lote deve-se iniciar um novo pois segmentos não se repetem